### PR TITLE
feat: Enable SIMD optimizations

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,24 +8,44 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_python3.10.____cpython:
-        CONFIG: linux_64_python3.10.____cpython
+      linux_64_microarch_level1python3.10.____cpython:
+        CONFIG: linux_64_microarch_level1python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_python3.11.____cpython:
-        CONFIG: linux_64_python3.11.____cpython
+      linux_64_microarch_level1python3.11.____cpython:
+        CONFIG: linux_64_microarch_level1python3.11.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_python3.12.____cpython:
-        CONFIG: linux_64_python3.12.____cpython
+      linux_64_microarch_level1python3.12.____cpython:
+        CONFIG: linux_64_microarch_level1python3.12.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_python3.13.____cp313:
-        CONFIG: linux_64_python3.13.____cp313
+      linux_64_microarch_level1python3.13.____cp313:
+        CONFIG: linux_64_microarch_level1python3.13.____cp313
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_python3.9.____cpython:
-        CONFIG: linux_64_python3.9.____cpython
+      linux_64_microarch_level1python3.9.____cpython:
+        CONFIG: linux_64_microarch_level1python3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_microarch_level3python3.10.____cpython:
+        CONFIG: linux_64_microarch_level3python3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_microarch_level3python3.11.____cpython:
+        CONFIG: linux_64_microarch_level3python3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_microarch_level3python3.12.____cpython:
+        CONFIG: linux_64_microarch_level3python3.12.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_microarch_level3python3.13.____cp313:
+        CONFIG: linux_64_microarch_level3python3.13.____cp313
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_microarch_level3python3.9.____cpython:
+        CONFIG: linux_64_microarch_level3python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_aarch64_python3.10.____cpython:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,20 +8,35 @@ jobs:
     vmImage: macOS-12
   strategy:
     matrix:
-      osx_64_python3.10.____cpython:
-        CONFIG: osx_64_python3.10.____cpython
+      osx_64_microarch_level1python3.10.____cpython:
+        CONFIG: osx_64_microarch_level1python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
-      osx_64_python3.11.____cpython:
-        CONFIG: osx_64_python3.11.____cpython
+      osx_64_microarch_level1python3.11.____cpython:
+        CONFIG: osx_64_microarch_level1python3.11.____cpython
         UPLOAD_PACKAGES: 'True'
-      osx_64_python3.12.____cpython:
-        CONFIG: osx_64_python3.12.____cpython
+      osx_64_microarch_level1python3.12.____cpython:
+        CONFIG: osx_64_microarch_level1python3.12.____cpython
         UPLOAD_PACKAGES: 'True'
-      osx_64_python3.13.____cp313:
-        CONFIG: osx_64_python3.13.____cp313
+      osx_64_microarch_level1python3.13.____cp313:
+        CONFIG: osx_64_microarch_level1python3.13.____cp313
         UPLOAD_PACKAGES: 'True'
-      osx_64_python3.9.____cpython:
-        CONFIG: osx_64_python3.9.____cpython
+      osx_64_microarch_level1python3.9.____cpython:
+        CONFIG: osx_64_microarch_level1python3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_64_microarch_level3python3.10.____cpython:
+        CONFIG: osx_64_microarch_level3python3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_64_microarch_level3python3.11.____cpython:
+        CONFIG: osx_64_microarch_level3python3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_64_microarch_level3python3.12.____cpython:
+        CONFIG: osx_64_microarch_level3python3.12.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_64_microarch_level3python3.13.____cp313:
+        CONFIG: osx_64_microarch_level3python3.13.____cp313
+        UPLOAD_PACKAGES: 'True'
+      osx_64_microarch_level3python3.9.____cpython:
+        CONFIG: osx_64_microarch_level3python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
       osx_arm64_python3.10.____cpython:
         CONFIG: osx_arm64_python3.10.____cpython

--- a/.ci_support/linux_64_microarch_level1python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_microarch_level1python3.10.____cpython.yaml
@@ -1,0 +1,31 @@
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+microarch_level:
+- '1'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+target_platform:
+- linux-64
+zip_keys:
+- - c_stdlib_version
+  - cdt_name
+- - python
+  - channel_sources

--- a/.ci_support/linux_64_microarch_level1python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_microarch_level1python3.11.____cpython.yaml
@@ -1,29 +1,31 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
-MACOSX_SDK_VERSION:
-- '10.13'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '10.13'
+- '2.17'
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '17'
-macos_machine:
-- x86_64-apple-darwin13.4.0
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+microarch_level:
+- '1'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.12.* *_cpython
+- 3.11.* *_cpython
 target_platform:
-- osx-64
+- linux-64
 zip_keys:
+- - c_stdlib_version
+  - cdt_name
 - - python
   - channel_sources

--- a/.ci_support/linux_64_microarch_level1python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_microarch_level1python3.12.____cpython.yaml
@@ -5,7 +5,7 @@ c_stdlib_version:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/python_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -14,12 +14,14 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+microarch_level:
+- '1'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.13.* *_cp313
+- 3.12.* *_cpython
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_microarch_level1python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_microarch_level1python3.13.____cp313.yaml
@@ -1,0 +1,31 @@
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge/label/python_rc,conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+microarch_level:
+- '1'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.13.* *_cp313
+target_platform:
+- linux-64
+zip_keys:
+- - c_stdlib_version
+  - cdt_name
+- - python
+  - channel_sources

--- a/.ci_support/linux_64_microarch_level1python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_microarch_level1python3.9.____cpython.yaml
@@ -14,12 +14,14 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+microarch_level:
+- '1'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.12.* *_cpython
+- 3.9.* *_cpython
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_microarch_level3python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_microarch_level3python3.10.____cpython.yaml
@@ -14,6 +14,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+microarch_level:
+- '3'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_microarch_level3python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_microarch_level3python3.11.____cpython.yaml
@@ -14,6 +14,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+microarch_level:
+- '3'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_microarch_level3python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_microarch_level3python3.12.____cpython.yaml
@@ -1,29 +1,31 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
-MACOSX_SDK_VERSION:
-- '10.13'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '10.13'
+- '2.17'
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '17'
-macos_machine:
-- x86_64-apple-darwin13.4.0
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+microarch_level:
+- '3'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.12.* *_cpython
 target_platform:
-- osx-64
+- linux-64
 zip_keys:
+- - c_stdlib_version
+  - cdt_name
 - - python
   - channel_sources

--- a/.ci_support/linux_64_microarch_level3python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_microarch_level3python3.13.____cp313.yaml
@@ -1,21 +1,21 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
-MACOSX_SDK_VERSION:
-- '10.13'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '10.13'
+- '2.17'
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge/label/python_rc,conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '17'
-macos_machine:
-- x86_64-apple-darwin13.4.0
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+microarch_level:
+- '3'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -23,7 +23,9 @@ pin_run_as_build:
 python:
 - 3.13.* *_cp313
 target_platform:
-- osx-64
+- linux-64
 zip_keys:
+- - c_stdlib_version
+  - cdt_name
 - - python
   - channel_sources

--- a/.ci_support/linux_64_microarch_level3python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_microarch_level3python3.9.____cpython.yaml
@@ -1,0 +1,31 @@
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+microarch_level:
+- '3'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+target_platform:
+- linux-64
+zip_keys:
+- - c_stdlib_version
+  - cdt_name
+- - python
+  - channel_sources

--- a/.ci_support/osx_64_microarch_level1python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level1python3.10.____cpython.yaml
@@ -1,0 +1,31 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '17'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+microarch_level:
+- '1'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+target_platform:
+- osx-64
+zip_keys:
+- - python
+  - channel_sources

--- a/.ci_support/osx_64_microarch_level1python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level1python3.11.____cpython.yaml
@@ -1,0 +1,31 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '17'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+microarch_level:
+- '1'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+target_platform:
+- osx-64
+zip_keys:
+- - python
+  - channel_sources

--- a/.ci_support/osx_64_microarch_level1python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level1python3.12.____cpython.yaml
@@ -1,29 +1,31 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
-cdt_name:
-- cos7
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '13'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- '17'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+microarch_level:
+- '1'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.12.* *_cpython
 target_platform:
-- linux-64
+- osx-64
 zip_keys:
-- - c_stdlib_version
-  - cdt_name
 - - python
   - channel_sources

--- a/.ci_support/osx_64_microarch_level1python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_microarch_level1python3.13.____cp313.yaml
@@ -1,0 +1,31 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
+channel_sources:
+- conda-forge/label/python_rc,conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '17'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+microarch_level:
+- '1'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.13.* *_cp313
+target_platform:
+- osx-64
+zip_keys:
+- - python
+  - channel_sources

--- a/.ci_support/osx_64_microarch_level1python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level1python3.9.____cpython.yaml
@@ -1,0 +1,31 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '17'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+microarch_level:
+- '1'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+target_platform:
+- osx-64
+zip_keys:
+- - python
+  - channel_sources

--- a/.ci_support/osx_64_microarch_level3python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level3python3.10.____cpython.yaml
@@ -1,0 +1,31 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '17'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+microarch_level:
+- '3'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+target_platform:
+- osx-64
+zip_keys:
+- - python
+  - channel_sources

--- a/.ci_support/osx_64_microarch_level3python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level3python3.11.____cpython.yaml
@@ -16,12 +16,14 @@ cxx_compiler_version:
 - '17'
 macos_machine:
 - x86_64-apple-darwin13.4.0
+microarch_level:
+- '3'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.11.* *_cpython
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_microarch_level3python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level3python3.12.____cpython.yaml
@@ -1,0 +1,31 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '17'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+microarch_level:
+- '3'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+target_platform:
+- osx-64
+zip_keys:
+- - python
+  - channel_sources

--- a/.ci_support/osx_64_microarch_level3python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_microarch_level3python3.13.____cp313.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '10.13'
 channel_sources:
-- conda-forge
+- conda-forge/label/python_rc,conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -16,12 +16,14 @@ cxx_compiler_version:
 - '17'
 macos_machine:
 - x86_64-apple-darwin13.4.0
+microarch_level:
+- '3'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.11.* *_cpython
+- 3.13.* *_cp313
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_microarch_level3python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level3python3.9.____cpython.yaml
@@ -1,0 +1,31 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '17'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+microarch_level:
+- '3'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+target_platform:
+- osx-64
+zip_keys:
+- - python
+  - channel_sources

--- a/README.md
+++ b/README.md
@@ -27,38 +27,73 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_python3.10.____cpython</td>
+              <td>linux_64_microarch_level1python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18400&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_python3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_microarch_level1python3.10.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_python3.11.____cpython</td>
+              <td>linux_64_microarch_level1python3.11.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18400&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_python3.11.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_microarch_level1python3.11.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_python3.12.____cpython</td>
+              <td>linux_64_microarch_level1python3.12.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18400&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_python3.12.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_microarch_level1python3.12.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_python3.13.____cp313</td>
+              <td>linux_64_microarch_level1python3.13.____cp313</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18400&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_python3.13.____cp313" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_microarch_level1python3.13.____cp313" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_python3.9.____cpython</td>
+              <td>linux_64_microarch_level1python3.9.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18400&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_microarch_level1python3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_microarch_level3python3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18400&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_microarch_level3python3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_microarch_level3python3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18400&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_microarch_level3python3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_microarch_level3python3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18400&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_microarch_level3python3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_microarch_level3python3.13.____cp313</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18400&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_microarch_level3python3.13.____cp313" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_microarch_level3python3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18400&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_microarch_level3python3.9.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -132,38 +167,73 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_python3.10.____cpython</td>
+              <td>osx_64_microarch_level1python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18400&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_python3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level1python3.10.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_python3.11.____cpython</td>
+              <td>osx_64_microarch_level1python3.11.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18400&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_python3.11.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level1python3.11.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_python3.12.____cpython</td>
+              <td>osx_64_microarch_level1python3.12.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18400&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_python3.12.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level1python3.12.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_python3.13.____cp313</td>
+              <td>osx_64_microarch_level1python3.13.____cp313</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18400&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_python3.13.____cp313" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level1python3.13.____cp313" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_python3.9.____cpython</td>
+              <td>osx_64_microarch_level1python3.9.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18400&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level1python3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_microarch_level3python3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18400&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level3python3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_microarch_level3python3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18400&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level3python3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_microarch_level3python3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18400&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level3python3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_microarch_level3python3.13.____cp313</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18400&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level3python3.13.____cp313" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_microarch_level3python3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18400&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level3python3.9.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,3 @@
+microarch_level:  # [unix and x86_64]
+  - 1  # [unix and x86_64]
+  - 3  # [unix and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "awkward-cpp" %}
 {% set version = "37" %}
+{% set build = 2 %}
 
 package:
   name: {{ name|lower }}
@@ -10,14 +11,20 @@ source:
   sha256: 6dff5fce4afcadb492bbf7cb20908572d99bdc32aa2bea8681bacfb69b2aa86d
 
 build:
+  # Prioritize builds with a higher microarch level.
+  # microarch_level 4 not supported yet.
+  # c.f. https://github.com/conda-forge/microarch-level-feedstock/issues/5
+  number: {{ build }}          # [not (unix and x86_64)]
+  number: {{ build + 100 }}    # [unix and x86_64 and microarch_level == 1]
+  number: {{ build + 300 }}    # [unix and x86_64 and microarch_level == 3]
   script:
     - {{ PYTHON }} -m pip install . -vv
-  number: 1
 
 requirements:
   build:
     - python                                 # [build_platform != target_platform]
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
+    - x86_64-microarch-level {{ microarch_level }}  # [unix and x86_64]
     - {{ compiler('cxx') }}
     - {{ stdlib("c") }}
     - cmake >=3.15


### PR DESCRIPTION
* Add x86_64-microarch-level as a 'build' requirement.
   - microarch_level 4 not supported yet so only add level 1 to 3.
   - c.f. https://github.com/conda-forge/microarch-level-feedstock/issues/5
* Set the build number based on the microarch_level.
* Add conda_build_config.yaml with microarch_level.
* c.f. https://prefix.dev/blog/building_cpu_optimized_packages
* Bump build number.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
