### PR TITLE
MNT: List at least one microarch_level to avoid redundant builds

### DIFF
--- a/.ci_support/linux_aarch64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.10.____cpython.yaml
@@ -14,6 +14,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+microarch_level:
+- '1'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.11.____cpython.yaml
@@ -14,6 +14,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+microarch_level:
+- '1'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.12.____cpython.yaml
@@ -14,6 +14,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+microarch_level:
+- '1'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_python3.13.____cp313.yaml
@@ -14,6 +14,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+microarch_level:
+- '1'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.9.____cpython.yaml
@@ -14,6 +14,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+microarch_level:
+- '1'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_ppc64le_python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.10.____cpython.yaml
@@ -14,6 +14,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+microarch_level:
+- '1'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_ppc64le_python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.11.____cpython.yaml
@@ -14,6 +14,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+microarch_level:
+- '1'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_ppc64le_python3.12.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.12.____cpython.yaml
@@ -14,6 +14,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+microarch_level:
+- '1'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_ppc64le_python3.13.____cp313.yaml
+++ b/.ci_support/linux_ppc64le_python3.13.____cp313.yaml
@@ -14,6 +14,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+microarch_level:
+- '1'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_ppc64le_python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.9.____cpython.yaml
@@ -14,6 +14,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+microarch_level:
+- '1'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.10.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '18'
 macos_machine:
 - arm64-apple-darwin20.0.0
+microarch_level:
+- '1'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.11.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '18'
 macos_machine:
 - arm64-apple-darwin20.0.0
+microarch_level:
+- '1'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.12.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '18'
 macos_machine:
 - arm64-apple-darwin20.0.0
+microarch_level:
+- '1'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_python3.13.____cp313.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '18'
 macos_machine:
 - arm64-apple-darwin20.0.0
+microarch_level:
+- '1'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.9.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '18'
 macos_machine:
 - arm64-apple-darwin20.0.0
+microarch_level:
+- '1'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_python3.10.____cpython.yaml
+++ b/.ci_support/win_64_python3.10.____cpython.yaml
@@ -6,6 +6,8 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2019
+microarch_level:
+- '1'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_python3.11.____cpython.yaml
+++ b/.ci_support/win_64_python3.11.____cpython.yaml
@@ -6,6 +6,8 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2019
+microarch_level:
+- '1'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_python3.12.____cpython.yaml
+++ b/.ci_support/win_64_python3.12.____cpython.yaml
@@ -6,6 +6,8 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2019
+microarch_level:
+- '1'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_python3.13.____cp313.yaml
+++ b/.ci_support/win_64_python3.13.____cp313.yaml
@@ -6,6 +6,8 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2019
+microarch_level:
+- '1'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_python3.9.____cpython.yaml
+++ b/.ci_support/win_64_python3.9.____cpython.yaml
@@ -6,6 +6,8 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2019
+microarch_level:
+- '1'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,3 @@
-microarch_level:  # [unix and x86_64]
-  - 1  # [unix and x86_64]
+microarch_level:
+  - 1
   - 3  # [unix and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "awkward-cpp" %}
 {% set version = "43" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
* Always list a microarch_level in recipe/conda_build_config.yaml to avoid conda-build searching for and setting an incorrect microarch_level, resulting in redundant builds..
   - c.f. https://github.com/conda-forge/conda-forge.github.io/pull/2197
* Bump build number.
* Resolves https://github.com/conda-forge/microarch-level-feedstock/issues/11

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
