### PR TITLE
MNT: Support up to microarch_level 2

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -28,24 +28,24 @@ jobs:
         CONFIG: linux_64_microarch_level1python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_microarch_level3python3.10.____cpython:
-        CONFIG: linux_64_microarch_level3python3.10.____cpython
+      linux_64_microarch_level2python3.10.____cpython:
+        CONFIG: linux_64_microarch_level2python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_microarch_level3python3.11.____cpython:
-        CONFIG: linux_64_microarch_level3python3.11.____cpython
+      linux_64_microarch_level2python3.11.____cpython:
+        CONFIG: linux_64_microarch_level2python3.11.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_microarch_level3python3.12.____cpython:
-        CONFIG: linux_64_microarch_level3python3.12.____cpython
+      linux_64_microarch_level2python3.12.____cpython:
+        CONFIG: linux_64_microarch_level2python3.12.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_microarch_level3python3.13.____cp313:
-        CONFIG: linux_64_microarch_level3python3.13.____cp313
+      linux_64_microarch_level2python3.13.____cp313:
+        CONFIG: linux_64_microarch_level2python3.13.____cp313
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_microarch_level3python3.9.____cpython:
-        CONFIG: linux_64_microarch_level3python3.9.____cpython
+      linux_64_microarch_level2python3.9.____cpython:
+        CONFIG: linux_64_microarch_level2python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_aarch64_python3.10.____cpython:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -23,20 +23,20 @@ jobs:
       osx_64_microarch_level1python3.9.____cpython:
         CONFIG: osx_64_microarch_level1python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
-      osx_64_microarch_level3python3.10.____cpython:
-        CONFIG: osx_64_microarch_level3python3.10.____cpython
+      osx_64_microarch_level2python3.10.____cpython:
+        CONFIG: osx_64_microarch_level2python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
-      osx_64_microarch_level3python3.11.____cpython:
-        CONFIG: osx_64_microarch_level3python3.11.____cpython
+      osx_64_microarch_level2python3.11.____cpython:
+        CONFIG: osx_64_microarch_level2python3.11.____cpython
         UPLOAD_PACKAGES: 'True'
-      osx_64_microarch_level3python3.12.____cpython:
-        CONFIG: osx_64_microarch_level3python3.12.____cpython
+      osx_64_microarch_level2python3.12.____cpython:
+        CONFIG: osx_64_microarch_level2python3.12.____cpython
         UPLOAD_PACKAGES: 'True'
-      osx_64_microarch_level3python3.13.____cp313:
-        CONFIG: osx_64_microarch_level3python3.13.____cp313
+      osx_64_microarch_level2python3.13.____cp313:
+        CONFIG: osx_64_microarch_level2python3.13.____cp313
         UPLOAD_PACKAGES: 'True'
-      osx_64_microarch_level3python3.9.____cpython:
-        CONFIG: osx_64_microarch_level3python3.9.____cpython
+      osx_64_microarch_level2python3.9.____cpython:
+        CONFIG: osx_64_microarch_level2python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
       osx_arm64_python3.10.____cpython:
         CONFIG: osx_arm64_python3.10.____cpython

--- a/.ci_support/linux_64_microarch_level2python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_microarch_level2python3.10.____cpython.yaml
@@ -15,12 +15,12 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 microarch_level:
-- '3'
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.13.* *_cp313
+- 3.10.* *_cpython
 target_platform:
 - linux-64

--- a/.ci_support/linux_64_microarch_level2python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_microarch_level2python3.11.____cpython.yaml
@@ -1,28 +1,26 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
-MACOSX_SDK_VERSION:
-- '10.13'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '10.13'
+- '2.17'
+cdt_name:
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '18'
-macos_machine:
-- x86_64-apple-darwin13.4.0
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 microarch_level:
-- '3'
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.12.* *_cpython
+- 3.11.* *_cpython
 target_platform:
-- osx-64
+- linux-64

--- a/.ci_support/linux_64_microarch_level2python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_microarch_level2python3.12.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 microarch_level:
-- '3'
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_microarch_level2python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_microarch_level2python3.13.____cp313.yaml
@@ -1,28 +1,26 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
-MACOSX_SDK_VERSION:
-- '10.13'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '10.13'
+- '2.17'
+cdt_name:
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '18'
-macos_machine:
-- x86_64-apple-darwin13.4.0
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 microarch_level:
-- '3'
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.11.* *_cpython
+- 3.13.* *_cp313
 target_platform:
-- osx-64
+- linux-64

--- a/.ci_support/linux_64_microarch_level2python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_microarch_level2python3.9.____cpython.yaml
@@ -1,23 +1,21 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
-MACOSX_SDK_VERSION:
-- '10.13'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '10.13'
+- '2.17'
+cdt_name:
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '18'
-macos_machine:
-- x86_64-apple-darwin13.4.0
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 microarch_level:
-- '3'
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -25,4 +23,4 @@ pin_run_as_build:
 python:
 - 3.9.* *_cpython
 target_platform:
-- osx-64
+- linux-64

--- a/.ci_support/osx_64_microarch_level2python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level2python3.10.____cpython.yaml
@@ -1,21 +1,23 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
-cdt_name:
-- conda
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '13'
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- '18'
+macos_machine:
+- x86_64-apple-darwin13.4.0
 microarch_level:
-- '3'
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -23,4 +25,4 @@ pin_run_as_build:
 python:
 - 3.10.* *_cpython
 target_platform:
-- linux-64
+- osx-64

--- a/.ci_support/osx_64_microarch_level2python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level2python3.11.____cpython.yaml
@@ -1,26 +1,28 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
-cdt_name:
-- conda
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '13'
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- '18'
+macos_machine:
+- x86_64-apple-darwin13.4.0
 microarch_level:
-- '3'
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.11.* *_cpython
 target_platform:
-- linux-64
+- osx-64

--- a/.ci_support/osx_64_microarch_level2python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level2python3.12.____cpython.yaml
@@ -17,12 +17,12 @@ cxx_compiler_version:
 macos_machine:
 - x86_64-apple-darwin13.4.0
 microarch_level:
-- '3'
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.13.* *_cp313
+- 3.12.* *_cpython
 target_platform:
 - osx-64

--- a/.ci_support/osx_64_microarch_level2python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_microarch_level2python3.13.____cp313.yaml
@@ -1,26 +1,28 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
-cdt_name:
-- conda
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '13'
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- '18'
+macos_machine:
+- x86_64-apple-darwin13.4.0
 microarch_level:
-- '3'
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.11.* *_cpython
+- 3.13.* *_cp313
 target_platform:
-- linux-64
+- osx-64

--- a/.ci_support/osx_64_microarch_level2python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level2python3.9.____cpython.yaml
@@ -17,12 +17,12 @@ cxx_compiler_version:
 macos_machine:
 - x86_64-apple-darwin13.4.0
 microarch_level:
-- '3'
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.9.* *_cpython
 target_platform:
 - osx-64

--- a/README.md
+++ b/README.md
@@ -62,38 +62,38 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_microarch_level3python3.10.____cpython</td>
+              <td>linux_64_microarch_level2python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18400&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_microarch_level3python3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_microarch_level2python3.10.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_microarch_level3python3.11.____cpython</td>
+              <td>linux_64_microarch_level2python3.11.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18400&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_microarch_level3python3.11.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_microarch_level2python3.11.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_microarch_level3python3.12.____cpython</td>
+              <td>linux_64_microarch_level2python3.12.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18400&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_microarch_level3python3.12.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_microarch_level2python3.12.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_microarch_level3python3.13.____cp313</td>
+              <td>linux_64_microarch_level2python3.13.____cp313</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18400&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_microarch_level3python3.13.____cp313" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_microarch_level2python3.13.____cp313" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_microarch_level3python3.9.____cpython</td>
+              <td>linux_64_microarch_level2python3.9.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18400&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_microarch_level3python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_microarch_level2python3.9.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -202,38 +202,38 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_microarch_level3python3.10.____cpython</td>
+              <td>osx_64_microarch_level2python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18400&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level3python3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level2python3.10.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_microarch_level3python3.11.____cpython</td>
+              <td>osx_64_microarch_level2python3.11.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18400&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level3python3.11.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level2python3.11.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_microarch_level3python3.12.____cpython</td>
+              <td>osx_64_microarch_level2python3.12.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18400&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level3python3.12.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level2python3.12.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_microarch_level3python3.13.____cp313</td>
+              <td>osx_64_microarch_level2python3.13.____cp313</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18400&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level3python3.13.____cp313" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level2python3.13.____cp313" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_microarch_level3python3.9.____cpython</td>
+              <td>osx_64_microarch_level2python3.9.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18400&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level3python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/awkward-cpp-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level2python3.9.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,3 @@
 microarch_level:
   - 1
-  - 3  # [unix and x86_64]
+  - 2  # [unix and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "awkward-cpp" %}
 {% set version = "43" %}
-{% set build = 1 %}
+{% set build = 2 %}
 
 package:
   name: {{ name|lower }}
@@ -14,9 +14,10 @@ build:
   # Prioritize builds with a higher microarch level.
   # microarch_level 4 not supported yet.
   # c.f. https://github.com/conda-forge/microarch-level-feedstock/issues/5
+  # Only use up to microarch_level 2 as unclear if level 3 has worthwhile benefits.
   number: {{ build }}  # [not (unix and x86_64)]
   number: {{ build + 100 }}  # [unix and x86_64 and microarch_level == 1]
-  number: {{ build + 300 }}  # [unix and x86_64 and microarch_level == 3]
+  number: {{ build + 200 }}  # [unix and x86_64 and microarch_level == 2]
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:


### PR DESCRIPTION
* Microarch level 2 should be generally useful, but it is unclear if level 3 actually is or not, so for the time being drop down to supporting up to level 2.
* Bump build number.

c.f. https://github.com/scientific-python/faster-scientific-python-ideas/issues/11#issuecomment-2494377023 for another example of level 3 being unclear at the moment.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
