### PR TITLE
ENH: update awkward-cpp to v53

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,6 +1,6 @@
 context:
   name: "awkward-cpp"
-  version: "52"
+  version: "53"
 
 package:
   name: ${{ name|lower }}
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/${{ name|replace('-', '_') }}-${{ version }}.tar.gz
-  sha256: ef141eb20544df261b973c986cfae57be329022061be86817506add676597275
+  sha256: a478d2b7de3754674294617e12bd6db10fce691e98f5df248d665da093cd4ffa
 
 build:
   number: 0


### PR DESCRIPTION
Bump awkward-cpp from v52 to v53.

- Version: 52 → 53
- SHA256: `a478d2b7de3754674294617e12bd6db10fce691e98f5df248d665da093cd4ffa`
- Build number reset to 0
- Based on upstream main (includes fix for multiarch CI failures from #83)

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Sonnet 4.6)

---

Closes #82